### PR TITLE
Added marts folders and updated some of the columns in staging and in…

### DIFF
--- a/models/intermediate/_int_models.yml
+++ b/models/intermediate/_int_models.yml
@@ -1,0 +1,27 @@
+version: 2
+
+models: 
+
+  - name: int_customers_joined_to_employees
+    description: This model contains details about customers, including associated employee information. 
+    columns:
+      - name: customer_id
+        tests: 
+          - unique
+          - not_null
+    
+  - name: int_invoice_lines_joined_to_invoices
+    description: This model combines the data from both the invoice_lines and invoices tables to display comprehensive payment details.
+    columns:
+      - name: "invoice_id || '-' || invoice_lineid"
+        tests: 
+          - unique
+          - not_null
+    
+  - name: int_tracks_joined_to_albums_artists_genre_mediatype
+    description: This model generates a dimension table containing all music-related attributes.
+    columns:
+      - name: track_id
+        tests: 
+          - unique
+          - not_null

--- a/models/intermediate/int_customers_joined_to_employees.sql
+++ b/models/intermediate/int_customers_joined_to_employees.sql
@@ -24,6 +24,7 @@ cutomer_and_employee as (
         employees.employee_id,
         employees.employee_first_name,
         employees.employee_last_name,
+        concat(employees.employee_first_name, employees.employee_first_name) as employee_name,
         employees.employee_title,
         employees.employee_birth_date,
         employees.employee_hired_date,

--- a/models/intermediate/int_tracks_joined_to_albums_artists_genre_mediatype.sql
+++ b/models/intermediate/int_tracks_joined_to_albums_artists_genre_mediatype.sql
@@ -31,14 +31,14 @@ tracks_joined_to_albums_artists_genre_mediatype as (
         music_tracks.genre_id,
         music_tracks.track_name,
         music_tracks.track_composer,
-        music_albums.album_name,
+        music_albums.album_title,
         music_artists.artist_name,
         music_media_types.mediatype_name,
         music_genres.genre_name,
         music_tracks.track_length_ms,
         music_tracks.track_length_seconds,
         music_tracks.track_length_mins,
-        music_tracks.Bytes,
+        music_tracks.bytes,
         music_tracks.unit_price
     from music_tracks
     left join music_genres

--- a/models/marts/dim_music_playlists.sql
+++ b/models/marts/dim_music_playlists.sql
@@ -1,0 +1,43 @@
+with music_playlist_tracks as (
+    select *
+    from {{ ref('stg_music__playlist_tracks')}}
+),
+
+music_playlists as (
+    select *
+    from {{ ref ('stg_music__playlists') }}
+),
+
+tracks_joined_to_albums_artists_genre_mediatype as (
+    select *
+    from {{ ref('int_tracks_joined_to_albums_artists_genre_mediatype')}}
+),
+
+music_playlist as (
+    select 
+        music_playlists.playlist_id,
+        music_playlist_tracks.track_id,
+        tracks_joined_to_albums_artists_genre_mediatype.album_id,
+        tracks_joined_to_albums_artists_genre_mediatype.mediatype_id,
+        tracks_joined_to_albums_artists_genre_mediatype.genre_id,
+        music_playlists.playlist_name,
+        tracks_joined_to_albums_artists_genre_mediatype.track_name,
+        tracks_joined_to_albums_artists_genre_mediatype.track_composer,
+        tracks_joined_to_albums_artists_genre_mediatype.album_title,
+        tracks_joined_to_albums_artists_genre_mediatype.artist_name,
+        tracks_joined_to_albums_artists_genre_mediatype.genre_name,
+        tracks_joined_to_albums_artists_genre_mediatype.mediatype_name,
+        tracks_joined_to_albums_artists_genre_mediatype.track_length_ms,
+        tracks_joined_to_albums_artists_genre_mediatype.track_length_seconds,
+        tracks_joined_to_albums_artists_genre_mediatype.track_length_mins,
+        tracks_joined_to_albums_artists_genre_mediatype.bytes,
+        tracks_joined_to_albums_artists_genre_mediatype.unit_price
+    from music_playlist_tracks
+    left join music_playlists
+        on music_playlist_tracks.playlist_id = music_playlists.playlist_id
+    left join tracks_joined_to_albums_artists_genre_mediatype
+        on music_playlist_tracks.track_id = tracks_joined_to_albums_artists_genre_mediatype.track_id
+)
+
+select *
+from music_playlist

--- a/models/marts/dim_music_tracks.sql
+++ b/models/marts/dim_music_tracks.sql
@@ -1,0 +1,27 @@
+with tracks_albums_artists_genre_mediatype as (
+    select *
+    from {{ ref('int_tracks_joined_to_albums_artists_genre_mediatype') }}
+),
+
+music_tracks as (
+    select 
+        tracks_albums_artists_genre_mediatype.track_id,
+        tracks_albums_artists_genre_mediatype.album_id,
+        tracks_albums_artists_genre_mediatype.mediatype_id,
+        tracks_albums_artists_genre_mediatype.genre_id,
+        tracks_albums_artists_genre_mediatype.track_name,
+        tracks_albums_artists_genre_mediatype.track_composer,
+        tracks_albums_artists_genre_mediatype.album_title,
+        tracks_albums_artists_genre_mediatype.artist_name,
+        tracks_albums_artists_genre_mediatype.mediatype_name,
+        tracks_albums_artists_genre_mediatype.genre_name,
+        tracks_albums_artists_genre_mediatype.track_length_ms,
+        tracks_albums_artists_genre_mediatype.track_length_seconds,
+        tracks_albums_artists_genre_mediatype.track_length_mins,
+        tracks_albums_artists_genre_mediatype.bytes,
+        tracks_albums_artists_genre_mediatype.unit_price
+    from tracks_albums_artists_genre_mediatype
+)
+
+select *
+from music_tracks

--- a/models/marts/fct_music_sales.sql
+++ b/models/marts/fct_music_sales.sql
@@ -1,0 +1,63 @@
+with invoice_lines_and_invoices as (
+    select *
+    from {{ ref('int_invoice_lines_joined_to_invoices') }}
+),
+
+customers_and_employees as (
+    select *
+    from {{ ref('int_customers_joined_to_employees') }}
+),
+
+tracks_albums_artists_genre_mediatype as (
+    select *
+    from {{ ref('int_tracks_joined_to_albums_artists_genre_mediatype') }}
+),
+
+music_sales as (
+    select 
+        invoice_lines_and_invoices.invoice_lineid,
+        invoice_lines_and_invoices.invoice_id,
+        tracks_albums_artists_genre_mediatype.track_id,
+        tracks_albums_artists_genre_mediatype.album_id,
+        tracks_albums_artists_genre_mediatype.mediatype_id,
+        tracks_albums_artists_genre_mediatype.genre_id,
+        customers_and_employees.customer_id,
+        customers_and_employees.employee_id,
+        invoice_lines_and_invoices.invoice_date_est,
+        invoice_lines_and_invoices.billing_state,
+        invoice_lines_and_invoices.billing_country,
+        invoice_lines_and_invoices.quantity_purchased,
+        invoice_lines_and_invoices.invoice_lineitem_revenue_usd,
+        tracks_albums_artists_genre_mediatype.track_name,
+        tracks_albums_artists_genre_mediatype.track_composer,
+        tracks_albums_artists_genre_mediatype.album_title,
+        tracks_albums_artists_genre_mediatype.artist_name,
+        tracks_albums_artists_genre_mediatype.mediatype_name,
+        tracks_albums_artists_genre_mediatype.genre_name,
+        tracks_albums_artists_genre_mediatype.track_length_ms,
+        tracks_albums_artists_genre_mediatype.track_length_seconds,
+        tracks_albums_artists_genre_mediatype.track_length_mins,
+        tracks_albums_artists_genre_mediatype.bytes,
+        customers_and_employees.customer_mailing_state,
+        customers_and_employees.customer_mailing_country,
+        customers_and_employees.customer_email_address,
+        customers_and_employees.employee_first_name,
+        customers_and_employees.employee_last_name,
+        customers_and_employees.employee_name,
+        customers_and_employees.employee_title,
+        customers_and_employees.employee_city,
+        customers_and_employees.employee_state,
+        customers_and_employees.employee_country
+    from invoice_lines_and_invoices
+    left join customers_and_employees
+        on 
+            invoice_lines_and_invoices.customer_id 
+            = customers_and_employees.customer_id
+    left join tracks_albums_artists_genre_mediatype
+        on 
+            invoice_lines_and_invoices.track_id
+            = tracks_albums_artists_genre_mediatype.track_id
+)
+
+select *
+from music_sales

--- a/models/staging/stg_music__albums.sql
+++ b/models/staging/stg_music__albums.sql
@@ -1,5 +1,5 @@
 select 
     albumid as album_id,
-    title as album_name,
+    title as album_title,
     artistid as artist_id
 from {{ source('music', 'album') }}


### PR DESCRIPTION
## Description & motivation

Created marts folders where we have 3 models: 
1. music_playlists
2.  music_tracks 
3. music_sales. 

This is created so that the end-user can make the business decision based on the metrics present in the final mart models.

#### New models

**fct_music_sales**: This table essentially serves as a comprehensive record of all transactions, including detailed information about the purchased songs.
**dim_music_tracks**:  This model includes a catalog of songs along with various identifiers.
**dim_music_playlists**: This model encompasses playlists containing comprehensive information about each of the listed songs.


#### Changes to existing models:

int_customers_joined_to_employees.sql
int_tracks_joined_to_albums_artists_genre_mediatype.sql
stg_music__albums.sql
